### PR TITLE
docs: simplify CLI examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,42 +90,8 @@ go build ./cmd/elava
 # Scan specific region
 ./elava scan --region us-west-2
 
-# Scan with attribution
-./elava scan --explain-drift
-
 # Filter resource types
 ./elava scan --filter ec2
-./elava scan --filter rds
-
-# Tiered scanning (fast → thorough)
-./elava scan --tiers
-```
-
-## Example: Drift Attribution
-
-```bash
-$ ./elava explain i-mysterious-instance
-
-📊 Attribution Report for i-mysterious-instance
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Resource Type: EC2 Instance
-Current State: Running
-Tags: {} (no tags)
-
-🕵️ Attribution:
-Actor: john.doe@company.com
-Action: RunInstances
-Timestamp: 2024-09-21 03:15:23 UTC
-Source: AWS Console (73.162.248.123)
-Confidence: 0.92 (High)
-
-📝 Context:
-- Created outside business hours
-- No associated Terraform/CloudFormation
-- Similar to previous debug instances
-
-🎯 Recommendation:
-Contact john.doe@company.com for cleanup
 ```
 
 ## Core Components
@@ -287,21 +253,6 @@ policies:
       oversized_instances: notify
 ```
 
-### CLI Integration
-
-```bash
-# Evaluate policies
-./elava policy evaluate --resource i-123456
-
-# Apply policies with dry-run
-./elava policy apply --dry-run
-
-# Show policy violations
-./elava policy violations --last 24h
-
-# Test policy against resource
-./elava policy test policies/tagging.rego --resource-file resource.json
-```
 
 ## Integration with FinOps Tools
 


### PR DESCRIPTION
Remove speculative CLI commands that aren't implemented yet:
- Removed attribution CLI examples (explain, --explain-drift)
- Removed policy CLI examples (evaluate, apply, violations)
- Kept only basic, working scan commands

Better to show what actually works than promise features that don't exist yet.