### PR TITLE
feat: add minimal policy enforcement 

### DIFF
--- a/policy/enforcer.go
+++ b/policy/enforcer.go
@@ -1,0 +1,72 @@
+package policy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/yairfalse/elava/telemetry"
+	"github.com/yairfalse/elava/types"
+)
+
+// Enforcer executes policy decisions
+type Enforcer struct {
+	logger *telemetry.Logger
+}
+
+// NewEnforcer creates a new enforcer
+func NewEnforcer() *Enforcer {
+	return &Enforcer{
+		logger: telemetry.NewLogger("policy-enforcer"),
+	}
+}
+
+// Execute enforces a policy decision on a resource
+func (e *Enforcer) Execute(ctx context.Context, decision PolicyResult, resource types.Resource) error {
+	e.logger.WithContext(ctx).Info().
+		Str("resource_id", resource.ID).
+		Str("resource_type", resource.Type).
+		Str("action", decision.Action).
+		Str("reason", decision.Reason).
+		Msg("executing policy enforcement")
+
+	switch decision.Action {
+	case "ignore":
+		return nil
+	case "notify":
+		return e.notify(ctx, resource, decision.Reason)
+	case "flag":
+		return e.flag(ctx, resource, decision)
+	default:
+		e.logger.WithContext(ctx).Warn().
+			Str("action", decision.Action).
+			Msg("unknown enforcement action")
+		return nil
+	}
+}
+
+func (e *Enforcer) notify(ctx context.Context, resource types.Resource, reason string) error {
+	message := fmt.Sprintf("Policy Alert: Resource %s (%s) - %s", resource.ID, resource.Type, reason)
+
+	e.logger.WithContext(ctx).Info().
+		Str("notification", message).
+		Msg("notification sent")
+
+	// TODO: Future - send to Slack/Discord
+	fmt.Println(message)
+	return nil
+}
+
+func (e *Enforcer) flag(ctx context.Context, resource types.Resource, decision PolicyResult) error {
+	tags := map[string]string{
+		"elava:policy-flag":   decision.Decision,
+		"elava:policy-reason": decision.Reason,
+	}
+
+	e.logger.WithContext(ctx).Info().
+		Str("resource_id", resource.ID).
+		Interface("tags", tags).
+		Msg("flagging resource with policy tags")
+
+	// TODO: Future - call provider.TagResource
+	return nil
+}

--- a/policy/enforcer_test.go
+++ b/policy/enforcer_test.go
@@ -1,0 +1,67 @@
+package policy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yairfalse/elava/types"
+)
+
+func TestEnforcer_ExecuteNotify(t *testing.T) {
+	// Test that notify action sends notification
+	enforcer := NewEnforcer()
+
+	decision := PolicyResult{
+		Decision: "flag",
+		Action:   "notify",
+		Reason:   "Resource is orphaned",
+	}
+
+	resource := types.Resource{
+		ID:   "i-123",
+		Type: "ec2",
+	}
+
+	err := enforcer.Execute(context.Background(), decision, resource)
+	assert.NoError(t, err)
+}
+
+func TestEnforcer_ExecuteFlag(t *testing.T) {
+	// Test that flag action tags resource
+	enforcer := NewEnforcer()
+
+	decision := PolicyResult{
+		Decision: "deny",
+		Action:   "flag",
+		Reason:   "Missing required tags",
+	}
+
+	resource := types.Resource{
+		ID:   "i-456",
+		Type: "ec2",
+	}
+
+	err := enforcer.Execute(context.Background(), decision, resource)
+	assert.NoError(t, err)
+}
+
+func TestEnforcer_IgnoreAction(t *testing.T) {
+	// Test that ignore action does nothing
+	enforcer := NewEnforcer()
+
+	decision := PolicyResult{
+		Decision: "allow",
+		Action:   "ignore",
+		Reason:   "Resource is compliant",
+	}
+
+	resource := types.Resource{
+		ID:   "i-789",
+		Type: "ec2",
+	}
+
+	err := enforcer.Execute(context.Background(), decision, resource)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Implements basic policy enforcement following CLAUDE.md workflow:
- Design session first with clear problem/solution
- Tests before implementation
- Small focused functions (<30 lines each)

Enforcement actions:
- ignore: No action for compliant resources
- notify: Log/stdout notification (future: Slack/Discord)
- flag: Prepare tags for resources (future: AWS tagging)



Tests pass, fmt/vet/lint clean.

