### PR TITLE
feat: store enforcement actions in MVCC for audit trail (LEAN batch 3)

### DIFF
--- a/policy/enforcer.go
+++ b/policy/enforcer.go
@@ -3,8 +3,10 @@ package policy
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/yairfalse/elava/providers"
+	"github.com/yairfalse/elava/storage"
 	"github.com/yairfalse/elava/telemetry"
 	"github.com/yairfalse/elava/types"
 )
@@ -13,6 +15,7 @@ import (
 type Enforcer struct {
 	logger   *telemetry.Logger
 	provider providers.CloudProvider
+	storage  *storage.MVCCStorage
 }
 
 // NewEnforcer creates a new enforcer without provider (dry-run mode)
@@ -30,6 +33,23 @@ func NewEnforcerWithProvider(provider providers.CloudProvider) *Enforcer {
 	}
 }
 
+// NewEnforcerWithStorage creates an enforcer that stores events
+func NewEnforcerWithStorage(storage *storage.MVCCStorage) *Enforcer {
+	return &Enforcer{
+		logger:  telemetry.NewLogger("policy-enforcer"),
+		storage: storage,
+	}
+}
+
+// NewEnforcerWithStorageAndProvider creates a full enforcer
+func NewEnforcerWithStorageAndProvider(storage *storage.MVCCStorage, provider providers.CloudProvider) *Enforcer {
+	return &Enforcer{
+		logger:   telemetry.NewLogger("policy-enforcer"),
+		storage:  storage,
+		provider: provider,
+	}
+}
+
 // Execute enforces a policy decision on a resource
 func (e *Enforcer) Execute(ctx context.Context, decision PolicyResult, resource types.Resource) error {
 	e.logger.WithContext(ctx).Info().
@@ -39,19 +59,57 @@ func (e *Enforcer) Execute(ctx context.Context, decision PolicyResult, resource 
 		Str("reason", decision.Reason).
 		Msg("executing policy enforcement")
 
+	// Create enforcement event
+	event := types.EnforcementEvent{
+		Timestamp:    time.Now(),
+		ResourceID:   resource.ID,
+		ResourceType: resource.Type,
+		Provider:     resource.Provider,
+		Action:       decision.Action,
+		Decision:     decision.Decision,
+		Reason:       decision.Reason,
+		Success:      true,
+	}
+
+	// Execute the action
+	var err error
 	switch decision.Action {
 	case "ignore":
-		return nil
+		// No action needed
 	case "notify":
-		return e.notify(ctx, resource, decision.Reason)
+		err = e.notify(ctx, resource, decision.Reason)
 	case "flag":
-		return e.flag(ctx, resource, decision)
+		tags := map[string]string{
+			"elava:policy-flag":   decision.Decision,
+			"elava:policy-reason": decision.Reason,
+		}
+		event.Tags = tags
+		err = e.flag(ctx, resource, decision)
 	default:
 		e.logger.WithContext(ctx).Warn().
 			Str("action", decision.Action).
 			Msg("unknown enforcement action")
-		return nil
 	}
+
+	// Record failure if any
+	if err != nil {
+		event.Success = false
+		event.Error = err.Error()
+	}
+
+	// Store event (non-blocking)
+	if e.storage != nil {
+		go func() {
+			if storeErr := e.storage.StoreEnforcement(context.Background(), event); storeErr != nil {
+				e.logger.Error().
+					Err(storeErr).
+					Str("resource_id", resource.ID).
+					Msg("failed to store enforcement event")
+			}
+		}()
+	}
+
+	return err
 }
 
 func (e *Enforcer) notify(ctx context.Context, resource types.Resource, reason string) error {

--- a/policy/enforcer_storage_test.go
+++ b/policy/enforcer_storage_test.go
@@ -1,0 +1,111 @@
+package policy
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yairfalse/elava/storage"
+	"github.com/yairfalse/elava/types"
+)
+
+func TestEnforcer_StoresEnforcementEvents(t *testing.T) {
+	// Create temp storage
+	tmpDir := t.TempDir()
+	store, err := storage.NewMVCCStorage(tmpDir)
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+
+	// Create enforcer with storage
+	enforcer := NewEnforcerWithStorage(store)
+
+	decision := PolicyResult{
+		Decision: "deny",
+		Action:   "flag",
+		Reason:   "Missing tags",
+	}
+
+	resource := types.Resource{
+		ID:       "i-123",
+		Type:     "ec2",
+		Provider: "aws",
+	}
+
+	// Execute enforcement
+	err = enforcer.Execute(context.Background(), decision, resource)
+	assert.NoError(t, err)
+
+	// Wait for async storage
+	time.Sleep(100 * time.Millisecond)
+
+	// Query stored events
+	events, err := store.QueryEnforcements(context.Background(), types.ResourceFilter{
+		IDs: []string{"i-123"},
+	})
+	require.NoError(t, err)
+	assert.Len(t, events, 1)
+
+	// Verify event details
+	event := events[0]
+	assert.Equal(t, "i-123", event.ResourceID)
+	assert.Equal(t, "flag", event.Action)
+	assert.Equal(t, "deny", event.Decision)
+	assert.Equal(t, "Missing tags", event.Reason)
+	assert.True(t, event.Success)
+}
+
+func TestEnforcer_StoresFailedEnforcement(t *testing.T) {
+	// Create temp storage
+	tmpDir := t.TempDir()
+	store, err := storage.NewMVCCStorage(tmpDir)
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+
+	// Mock provider that fails
+	mockProvider := &FailingMockProvider{}
+
+	// Create enforcer with storage and failing provider
+	enforcer := NewEnforcerWithStorageAndProvider(store, mockProvider)
+
+	decision := PolicyResult{
+		Decision: "deny",
+		Action:   "flag",
+		Reason:   "Policy violation",
+	}
+
+	resource := types.Resource{
+		ID:   "i-456",
+		Type: "ec2",
+	}
+
+	// Execute enforcement (will fail)
+	err = enforcer.Execute(context.Background(), decision, resource)
+	assert.Error(t, err)
+
+	// Wait for async storage
+	time.Sleep(100 * time.Millisecond)
+
+	// Query stored events
+	events, err := store.QueryEnforcements(context.Background(), types.ResourceFilter{
+		IDs: []string{"i-456"},
+	})
+	require.NoError(t, err)
+	assert.Len(t, events, 1)
+
+	// Verify failure is recorded
+	event := events[0]
+	assert.False(t, event.Success)
+	assert.Contains(t, event.Error, "mock failure")
+}
+
+// FailingMockProvider for testing
+type FailingMockProvider struct {
+	MockProvider
+}
+
+func (f *FailingMockProvider) TagResource(ctx context.Context, id string, tags map[string]string) error {
+	return fmt.Errorf("mock failure: unable to tag resource")
+}

--- a/storage/enforcement.go
+++ b/storage/enforcement.go
@@ -1,0 +1,113 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/yairfalse/elava/types"
+	"go.etcd.io/bbolt"
+)
+
+// StoreEnforcement stores an enforcement event
+func (s *MVCCStorage) StoreEnforcement(ctx context.Context, event types.EnforcementEvent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Generate key with timestamp for ordering
+	key := fmt.Sprintf("enforcement:%d:%s", event.Timestamp.UnixNano(), event.ResourceID)
+
+	// Serialize event
+	data, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("failed to marshal enforcement event: %w", err)
+	}
+
+	// Store in database
+	err = s.db.Update(func(tx *bbolt.Tx) error {
+		bucket, err := tx.CreateBucketIfNotExists([]byte("enforcements"))
+		if err != nil {
+			return err
+		}
+		return bucket.Put([]byte(key), data)
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to store enforcement event: %w", err)
+	}
+
+	s.currentRev++
+	return nil
+}
+
+// QueryEnforcements retrieves enforcement events by filter
+func (s *MVCCStorage) QueryEnforcements(ctx context.Context, filter types.ResourceFilter) ([]types.EnforcementEvent, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var events []types.EnforcementEvent
+	prefix := []byte("enforcement:")
+
+	err := s.db.View(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket([]byte("enforcements"))
+		if bucket == nil {
+			return nil // No events yet
+		}
+
+		// Scan all keys with prefix
+		c := bucket.Cursor()
+		for k, v := c.Seek(prefix); k != nil && len(k) >= len(prefix); k, v = c.Next() {
+			// Check prefix match
+			if string(k[:len(prefix)]) != string(prefix) {
+				break
+			}
+
+			// Deserialize event
+			var event types.EnforcementEvent
+			if err := json.Unmarshal(v, &event); err != nil {
+				continue // Skip malformed events
+			}
+
+			// Apply filters
+			if !matchesFilter(event, filter) {
+				continue
+			}
+
+			events = append(events, event)
+		}
+		return nil
+	})
+
+	return events, err
+}
+
+func matchesFilter(event types.EnforcementEvent, filter types.ResourceFilter) bool {
+	// Filter by resource IDs
+	if len(filter.IDs) > 0 {
+		found := false
+		for _, id := range filter.IDs {
+			if event.ResourceID == id {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	// Filter by type
+	if filter.Type != "" && event.ResourceType != filter.Type {
+		return false
+	}
+
+	// Filter by provider
+	if filter.Provider != "" && event.Provider != filter.Provider {
+		return false
+	}
+
+	// Note: ResourceFilter doesn't have Since field, so we don't filter by time
+	// Could add a separate EnforcementFilter type if needed
+
+	return true
+}

--- a/types/enforcement.go
+++ b/types/enforcement.go
@@ -1,0 +1,17 @@
+package types
+
+import "time"
+
+// EnforcementEvent records a policy enforcement action
+type EnforcementEvent struct {
+	Timestamp    time.Time         `json:"timestamp"`
+	ResourceID   string            `json:"resource_id"`
+	ResourceType string            `json:"resource_type"`
+	Provider     string            `json:"provider"`
+	Action       string            `json:"action"` // notify, flag, deny, ignore
+	Decision     string            `json:"decision"`
+	Reason       string            `json:"reason"`
+	Tags         map[string]string `json:"tags,omitempty"` // Tags applied if action=flag
+	Success      bool              `json:"success"`
+	Error        string            `json:"error,omitempty"`
+}


### PR DESCRIPTION
Implements enforcement event storage following CLAUDE.md:
- Design session with storage-first thinking
- Tests before implementation
- Small focused functions

Storage features:
- EnforcementEvent type tracks all enforcement details
- Store events in bbolt with timestamp-ordered keys
- Query events by resource ID, type, provider
- Non-blocking async storage to avoid slowing enforcement

Architecture:
- Events stored in "enforcements" bucket
- Key pattern: enforcement:{timestamp}:{resource_id}
- Storage failures logged but don't block enforcement
- Full audit trail for compliance/debugging

Testing:
- Verify successful enforcement is recorded
- Verify failed enforcement is recorded with error
- Mock providers for testing failure cases

Following LEAN principles:
- Minimal working implementation
- Could extend with time-range filters later
- Non-blocking storage for performance

All tests pass, fmt/vet/lint clean.
