### PR TITLE
Feat/storage interface fixing 

### DIFF
--- a/storage/analyzer_events.go
+++ b/storage/analyzer_events.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"time"

--- a/storage/analyzer_events.go
+++ b/storage/analyzer_events.go
@@ -17,18 +17,18 @@ var (
 	bucketWaste   = []byte("waste")
 )
 
-// StoreChangeEvent stores a change event (generic interface{})
-func (s *MVCCStorage) StoreChangeEvent(ctx context.Context, event interface{}) error {
+// StoreChangeEvent stores a change event
+func (s *MVCCStorage) StoreChangeEvent(ctx context.Context, event ChangeEvent) error {
 	return s.storeAnalyzerEvent(ctx, bucketChanges, event)
 }
 
-// StoreDriftEvent stores a drift event (generic interface{})
-func (s *MVCCStorage) StoreDriftEvent(ctx context.Context, event interface{}) error {
+// StoreDriftEvent stores a drift event
+func (s *MVCCStorage) StoreDriftEvent(ctx context.Context, event DriftEvent) error {
 	return s.storeAnalyzerEvent(ctx, bucketDrift, event)
 }
 
-// StoreWastePattern stores a waste pattern (generic interface{})
-func (s *MVCCStorage) StoreWastePattern(ctx context.Context, pattern interface{}) error {
+// StoreWastePattern stores a waste pattern
+func (s *MVCCStorage) StoreWastePattern(ctx context.Context, pattern WastePattern) error {
 	return s.storeAnalyzerEvent(ctx, bucketWaste, pattern)
 }
 

--- a/storage/analyzer_events.go
+++ b/storage/analyzer_events.go
@@ -19,46 +19,106 @@ var (
 
 // StoreChangeEvent stores a change event
 func (s *MVCCStorage) StoreChangeEvent(ctx context.Context, event ChangeEvent) error {
-	return s.storeAnalyzerEvent(ctx, bucketChanges, event)
+	return storeAnalyzerEvent(s, ctx, bucketChanges, event)
 }
 
 // StoreDriftEvent stores a drift event
 func (s *MVCCStorage) StoreDriftEvent(ctx context.Context, event DriftEvent) error {
-	return s.storeAnalyzerEvent(ctx, bucketDrift, event)
+	return storeAnalyzerEvent(s, ctx, bucketDrift, event)
 }
 
 // StoreWastePattern stores a waste pattern
 func (s *MVCCStorage) StoreWastePattern(ctx context.Context, pattern WastePattern) error {
-	return s.storeAnalyzerEvent(ctx, bucketWaste, pattern)
+	return storeAnalyzerEvent(s, ctx, bucketWaste, pattern)
 }
 
-// storeAnalyzerEvent stores any analyzer event
-func (s *MVCCStorage) storeAnalyzerEvent(ctx context.Context, bucketName []byte, data interface{}) error {
+// StoreChangeEventBatch stores multiple change events atomically
+func (s *MVCCStorage) StoreChangeEventBatch(ctx context.Context, events []ChangeEvent) error {
+	return storeAnalyzerEventBatch(s, bucketChanges, events)
+}
+
+// StoreDriftEventBatch stores multiple drift events atomically
+func (s *MVCCStorage) StoreDriftEventBatch(ctx context.Context, events []DriftEvent) error {
+	return storeAnalyzerEventBatch(s, bucketDrift, events)
+}
+
+// StoreWastePatternBatch stores multiple waste patterns atomically
+func (s *MVCCStorage) StoreWastePatternBatch(ctx context.Context, patterns []WastePattern) error {
+	return storeAnalyzerEventBatch(s, bucketWaste, patterns)
+}
+
+// storeAnalyzerEventBatch stores multiple events in a single transaction using generics
+func storeAnalyzerEventBatch[T any](s *MVCCStorage, bucketName []byte, events []T) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Get base timestamp for all events in batch
+	baseTimestamp := s.getCurrentTimestamp()
+
+	err := s.db.Update(func(tx *bbolt.Tx) error {
+		bucket, err := tx.CreateBucketIfNotExists(bucketName)
+		if err != nil {
+			return fmt.Errorf("failed to create bucket %s: %w", bucketName, err)
+		}
+
+		// Store each event in the batch
+		for i, event := range events {
+			key := makeAnalyzerEventKey(baseTimestamp, s.currentRev+int64(i+1))
+			value, err := json.Marshal(event)
+			if err != nil {
+				return fmt.Errorf("failed to marshal event at index %d: %w", i, err)
+			}
+			if err := bucket.Put(key, value); err != nil {
+				return fmt.Errorf("failed to put event at index %d: %w", i, err)
+			}
+		}
+
+		// Only increment revision on successful transaction
+		s.currentRev += int64(len(events))
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to store event batch in bucket %s: %w", bucketName, err)
+	}
+
+	return nil
+}
+
+// storeAnalyzerEvent stores any analyzer event using generics
+func storeAnalyzerEvent[T any](s *MVCCStorage, ctx context.Context, bucketName []byte, data T) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	// Use current time in nanoseconds for key
 	timestamp := s.getCurrentTimestamp()
-	key := makeAnalyzerEventKey(timestamp, s.currentRev)
 
 	value, err := json.Marshal(data)
 	if err != nil {
-		return fmt.Errorf("failed to marshal event: %w", err)
+		return fmt.Errorf("failed to marshal event for bucket %s: %w", bucketName, err)
 	}
 
 	err = s.db.Update(func(tx *bbolt.Tx) error {
 		bucket, err := tx.CreateBucketIfNotExists(bucketName)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to create bucket %s: %w", bucketName, err)
 		}
-		return bucket.Put(key, value)
+
+		// Create key inside transaction with next revision
+		key := makeAnalyzerEventKey(timestamp, s.currentRev+1)
+		if err := bucket.Put(key, value); err != nil {
+			return fmt.Errorf("failed to put event: %w", err)
+		}
+
+		// Only increment revision on successful transaction
+		s.currentRev++
+		return nil
 	})
 
 	if err != nil {
-		return fmt.Errorf("failed to store event: %w", err)
+		return fmt.Errorf("failed to store event in bucket %s: %w", bucketName, err)
 	}
 
-	s.currentRev++
 	return nil
 }
 
@@ -76,7 +136,7 @@ func (s *MVCCStorage) getTime() time.Time {
 // Uses timestamp (nanoseconds) + revision for uniqueness and ordering
 func makeAnalyzerEventKey(timestamp, revision int64) []byte {
 	key := make([]byte, 16)
-	binary.BigEndian.PutUint64(key[0:8], uint64(timestamp))
-	binary.BigEndian.PutUint64(key[8:16], uint64(revision))
+	binary.BigEndian.PutUint64(key[0:8], uint64(timestamp)) //nolint:gosec // timestamp is always positive
+	binary.BigEndian.PutUint64(key[8:16], uint64(revision)) //nolint:gosec // revision is always positive
 	return key
 }

--- a/storage/analyzer_events_bench_test.go
+++ b/storage/analyzer_events_bench_test.go
@@ -1,0 +1,115 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func BenchmarkStoreChangeEvent_Individual(b *testing.B) {
+	tmpDir := b.TempDir()
+	storage, err := NewMVCCStorage(tmpDir)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() { _ = storage.Close() }()
+
+	ctx := context.Background()
+	event := ChangeEvent{
+		ResourceID: "i-bench",
+		ChangeType: "created",
+		Timestamp:  time.Now(),
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := storage.StoreChangeEvent(ctx, event); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkStoreChangeEvent_Batch(b *testing.B) {
+	tmpDir := b.TempDir()
+	storage, err := NewMVCCStorage(tmpDir)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() { _ = storage.Close() }()
+
+	ctx := context.Background()
+	batchSize := 100
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		events := make([]ChangeEvent, batchSize)
+		for j := 0; j < batchSize; j++ {
+			events[j] = ChangeEvent{
+				ResourceID: "i-bench",
+				ChangeType: "created",
+				Timestamp:  time.Now(),
+			}
+		}
+		if err := storage.StoreChangeEventBatch(ctx, events); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkStoreDriftEvent_Individual(b *testing.B) {
+	tmpDir := b.TempDir()
+	storage, err := NewMVCCStorage(tmpDir)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() { _ = storage.Close() }()
+
+	ctx := context.Background()
+	event := DriftEvent{
+		ResourceID: "i-bench",
+		DriftType:  "tag_drift",
+		Field:      "env",
+		Expected:   "prod",
+		Actual:     "dev",
+		Severity:   "high",
+		Timestamp:  time.Now(),
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := storage.StoreDriftEvent(ctx, event); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkStoreDriftEvent_Batch(b *testing.B) {
+	tmpDir := b.TempDir()
+	storage, err := NewMVCCStorage(tmpDir)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() { _ = storage.Close() }()
+
+	ctx := context.Background()
+	batchSize := 100
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		events := make([]DriftEvent, batchSize)
+		for j := 0; j < batchSize; j++ {
+			events[j] = DriftEvent{
+				ResourceID: "i-bench",
+				DriftType:  "tag_drift",
+				Field:      "env",
+				Expected:   "prod",
+				Actual:     "dev",
+				Severity:   "high",
+				Timestamp:  time.Now(),
+			}
+		}
+		if err := storage.StoreDriftEventBatch(ctx, events); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/storage/analyzer_events_edge_test.go
+++ b/storage/analyzer_events_edge_test.go
@@ -1,0 +1,274 @@
+package storage
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestConcurrentAnalyzerEventWrites tests concurrent writes to analyzer events
+func TestConcurrentAnalyzerEventWrites(t *testing.T) {
+	tmpDir := t.TempDir()
+	storage, err := NewMVCCStorage(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = storage.Close() }()
+
+	ctx := context.Background()
+	const numGoroutines = 10
+	const eventsPerGoroutine = 20
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	// Launch concurrent writers
+	for i := 0; i < numGoroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < eventsPerGoroutine; j++ {
+				event := ChangeEvent{
+					ResourceID: "concurrent-test",
+					ChangeType: "created",
+					Timestamp:  time.Now(),
+				}
+				if err := storage.StoreChangeEvent(ctx, event); err != nil {
+					t.Errorf("goroutine %d: StoreChangeEvent failed: %v", id, err)
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify all events were stored
+	events, err := storage.QueryChangesSince(ctx, time.Now().Add(-1*time.Hour))
+	if err != nil {
+		t.Fatalf("QueryChangesSince failed: %v", err)
+	}
+
+	expectedCount := numGoroutines * eventsPerGoroutine
+	if len(events) != expectedCount {
+		t.Errorf("Expected %d events, got %d", expectedCount, len(events))
+	}
+
+	// Verify revision incremented correctly
+	finalRev := storage.CurrentRevision()
+	if finalRev != int64(expectedCount) {
+		t.Errorf("Revision = %d, want %d", finalRev, expectedCount)
+	}
+}
+
+// TestConcurrentBatchWrites tests concurrent batch writes
+func TestConcurrentBatchWrites(t *testing.T) {
+	tmpDir := t.TempDir()
+	storage, err := NewMVCCStorage(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = storage.Close() }()
+
+	ctx := context.Background()
+	const numGoroutines = 5
+	const batchSize = 10
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			events := make([]DriftEvent, batchSize)
+			for j := 0; j < batchSize; j++ {
+				events[j] = DriftEvent{
+					ResourceID: "batch-concurrent",
+					DriftType:  "test",
+					Field:      "test",
+					Expected:   "a",
+					Actual:     "b",
+					Severity:   "low",
+					Timestamp:  time.Now(),
+				}
+			}
+			if err := storage.StoreDriftEventBatch(ctx, events); err != nil {
+				t.Errorf("goroutine %d: StoreDriftEventBatch failed: %v", id, err)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify correct count
+	events, err := storage.QueryDriftEvents(ctx, time.Now().Add(-1*time.Hour))
+	if err != nil {
+		t.Fatalf("QueryDriftEvents failed: %v", err)
+	}
+
+	expectedCount := numGoroutines * batchSize
+	if len(events) != expectedCount {
+		t.Errorf("Expected %d events, got %d", expectedCount, len(events))
+	}
+}
+
+// TestRevisionNumberConsistency verifies revision numbers are sequential and unique
+func TestRevisionNumberConsistency(t *testing.T) {
+	tmpDir := t.TempDir()
+	storage, err := NewMVCCStorage(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = storage.Close() }()
+
+	ctx := context.Background()
+
+	// Store events and track expected revisions
+	initialRev := storage.CurrentRevision()
+
+	// Single event
+	if err := storage.StoreChangeEvent(ctx, ChangeEvent{
+		ResourceID: "r1",
+		ChangeType: "created",
+		Timestamp:  time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rev1 := storage.CurrentRevision()
+	if rev1 != initialRev+1 {
+		t.Errorf("After 1 event: revision = %d, want %d", rev1, initialRev+1)
+	}
+
+	// Batch of 3
+	if err := storage.StoreChangeEventBatch(ctx, []ChangeEvent{
+		{ResourceID: "r2", ChangeType: "created", Timestamp: time.Now()},
+		{ResourceID: "r3", ChangeType: "created", Timestamp: time.Now()},
+		{ResourceID: "r4", ChangeType: "created", Timestamp: time.Now()},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rev2 := storage.CurrentRevision()
+	if rev2 != rev1+3 {
+		t.Errorf("After batch of 3: revision = %d, want %d", rev2, rev1+3)
+	}
+
+	// Another single
+	if err := storage.StoreDriftEvent(ctx, DriftEvent{
+		ResourceID: "r5",
+		DriftType:  "test",
+		Field:      "f",
+		Expected:   "e",
+		Actual:     "a",
+		Severity:   "low",
+		Timestamp:  time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	finalRev := storage.CurrentRevision()
+	if finalRev != rev2+1 {
+		t.Errorf("After final event: revision = %d, want %d", finalRev, rev2+1)
+	}
+}
+
+// TestEmptyBatch tests behavior with empty batch
+func TestEmptyBatch(t *testing.T) {
+	tmpDir := t.TempDir()
+	storage, err := NewMVCCStorage(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = storage.Close() }()
+
+	ctx := context.Background()
+	initialRev := storage.CurrentRevision()
+
+	// Store empty batch - should succeed but not increment revision
+	emptyEvents := []ChangeEvent{}
+	if err := storage.StoreChangeEventBatch(ctx, emptyEvents); err != nil {
+		t.Errorf("Empty batch should succeed: %v", err)
+	}
+
+	finalRev := storage.CurrentRevision()
+	if finalRev != initialRev {
+		t.Errorf("Empty batch changed revision: %d → %d", initialRev, finalRev)
+	}
+}
+
+// TestMixedEventTypes ensures different event types don't interfere
+func TestMixedEventTypes(t *testing.T) {
+	tmpDir := t.TempDir()
+	storage, err := NewMVCCStorage(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = storage.Close() }()
+
+	ctx := context.Background()
+
+	// Store one of each type
+	changeEvent := ChangeEvent{
+		ResourceID: "r1",
+		ChangeType: "created",
+		Timestamp:  time.Now(),
+	}
+	if err := storage.StoreChangeEvent(ctx, changeEvent); err != nil {
+		t.Fatal(err)
+	}
+
+	driftEvent := DriftEvent{
+		ResourceID: "r2",
+		DriftType:  "config",
+		Field:      "size",
+		Expected:   "t2.micro",
+		Actual:     "t2.small",
+		Severity:   "medium",
+		Timestamp:  time.Now(),
+	}
+	if err := storage.StoreDriftEvent(ctx, driftEvent); err != nil {
+		t.Fatal(err)
+	}
+
+	wastePattern := WastePattern{
+		PatternType: "idle",
+		ResourceIDs: []string{"r3"},
+		Confidence:  0.9,
+		Reason:      "low usage",
+		Timestamp:   time.Now(),
+	}
+	if err := storage.StoreWastePattern(ctx, wastePattern); err != nil {
+		t.Fatal(err)
+	}
+
+	// Query each type independently
+	changes, err := storage.QueryChangesSince(ctx, time.Now().Add(-1*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(changes) != 1 {
+		t.Errorf("Changes: got %d, want 1", len(changes))
+	}
+
+	drifts, err := storage.QueryDriftEvents(ctx, time.Now().Add(-1*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(drifts) != 1 {
+		t.Errorf("Drifts: got %d, want 1", len(drifts))
+	}
+
+	wastes, err := storage.QueryWastePatterns(ctx, time.Now().Add(-1*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(wastes) != 1 {
+		t.Errorf("Wastes: got %d, want 1", len(wastes))
+	}
+
+	// Verify total revision
+	finalRev := storage.CurrentRevision()
+	if finalRev != 3 {
+		t.Errorf("Revision = %d, want 3", finalRev)
+	}
+}

--- a/storage/analyzer_events_test.go
+++ b/storage/analyzer_events_test.go
@@ -2,29 +2,9 @@ package storage
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 	"time"
 )
-
-type testChangeEvent struct {
-	Revision   int64
-	Timestamp  time.Time
-	ResourceID string
-	Type       string
-}
-
-type testDriftEvent struct {
-	ResourceID string
-	Field      string
-	Severity   string
-}
-
-type testWastePattern struct {
-	Type        string
-	ResourceIDs []string
-	Confidence  float64
-}
 
 func TestMVCCStorage_StoreAndQueryChangeEvents(t *testing.T) {
 	tmpDir := t.TempDir()
@@ -34,11 +14,11 @@ func TestMVCCStorage_StoreAndQueryChangeEvents(t *testing.T) {
 	}
 	defer func() { _ = storage.Close() }()
 
-	event := testChangeEvent{
-		Revision:   1,
-		Timestamp:  time.Now(),
+	event := ChangeEvent{
 		ResourceID: "i-123",
-		Type:       "created",
+		ChangeType: "created",
+		Timestamp:  time.Now(),
+		Revision:   1,
 	}
 
 	ctx := context.Background()
@@ -55,13 +35,12 @@ func TestMVCCStorage_StoreAndQueryChangeEvents(t *testing.T) {
 		t.Errorf("Expected 1 event, got %d", len(events))
 	}
 
-	var retrieved testChangeEvent
-	if err := json.Unmarshal(events[0], &retrieved); err != nil {
-		t.Fatalf("Failed to unmarshal: %v", err)
+	if events[0].ResourceID != "i-123" {
+		t.Errorf("ResourceID = %s, want i-123", events[0].ResourceID)
 	}
 
-	if retrieved.ResourceID != "i-123" {
-		t.Errorf("ResourceID = %s, want i-123", retrieved.ResourceID)
+	if events[0].ChangeType != "created" {
+		t.Errorf("ChangeType = %s, want created", events[0].ChangeType)
 	}
 }
 
@@ -73,9 +52,13 @@ func TestMVCCStorage_StoreAndQueryDriftEvents(t *testing.T) {
 	}
 	defer func() { _ = storage.Close() }()
 
-	event := testDriftEvent{
+	event := DriftEvent{
 		ResourceID: "i-456",
+		DriftType:  "config_drift",
+		Timestamp:  time.Now(),
 		Field:      "instance_type",
+		Expected:   "t2.micro",
+		Actual:     "t2.small",
 		Severity:   "medium",
 	}
 
@@ -93,13 +76,12 @@ func TestMVCCStorage_StoreAndQueryDriftEvents(t *testing.T) {
 		t.Errorf("Expected 1 event, got %d", len(events))
 	}
 
-	var retrieved testDriftEvent
-	if err := json.Unmarshal(events[0], &retrieved); err != nil {
-		t.Fatalf("Failed to unmarshal: %v", err)
+	if events[0].Field != "instance_type" {
+		t.Errorf("Field = %s, want instance_type", events[0].Field)
 	}
 
-	if retrieved.Field != "instance_type" {
-		t.Errorf("Field = %s, want instance_type", retrieved.Field)
+	if events[0].Severity != "medium" {
+		t.Errorf("Severity = %s, want medium", events[0].Severity)
 	}
 }
 
@@ -111,10 +93,12 @@ func TestMVCCStorage_StoreAndQueryWastePatterns(t *testing.T) {
 	}
 	defer func() { _ = storage.Close() }()
 
-	pattern := testWastePattern{
-		Type:        "orphaned",
+	pattern := WastePattern{
+		PatternType: "orphaned",
 		ResourceIDs: []string{"i-789", "i-abc"},
+		Timestamp:   time.Now(),
 		Confidence:  0.95,
+		Reason:      "No owner tag",
 	}
 
 	ctx := context.Background()
@@ -131,12 +115,11 @@ func TestMVCCStorage_StoreAndQueryWastePatterns(t *testing.T) {
 		t.Errorf("Expected 1 pattern, got %d", len(patterns))
 	}
 
-	var retrieved testWastePattern
-	if err := json.Unmarshal(patterns[0], &retrieved); err != nil {
-		t.Fatalf("Failed to unmarshal: %v", err)
+	if len(patterns[0].ResourceIDs) != 2 {
+		t.Errorf("Expected 2 resource IDs, got %d", len(patterns[0].ResourceIDs))
 	}
 
-	if len(retrieved.ResourceIDs) != 2 {
-		t.Errorf("Expected 2 resource IDs, got %d", len(retrieved.ResourceIDs))
+	if patterns[0].Confidence != 0.95 {
+		t.Errorf("Confidence = %f, want 0.95", patterns[0].Confidence)
 	}
 }

--- a/storage/analyzer_events_test.go
+++ b/storage/analyzer_events_test.go
@@ -123,3 +123,144 @@ func TestMVCCStorage_StoreAndQueryWastePatterns(t *testing.T) {
 		t.Errorf("Confidence = %f, want 0.95", patterns[0].Confidence)
 	}
 }
+
+func TestMVCCStorage_StoreChangeEventBatch(t *testing.T) {
+	tmpDir := t.TempDir()
+	storage, err := NewMVCCStorage(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create storage: %v", err)
+	}
+	defer func() { _ = storage.Close() }()
+
+	events := []ChangeEvent{
+		{ResourceID: "i-001", ChangeType: "created", Timestamp: time.Now(), Revision: 1},
+		{ResourceID: "i-002", ChangeType: "modified", Timestamp: time.Now(), Revision: 2},
+		{ResourceID: "i-003", ChangeType: "disappeared", Timestamp: time.Now(), Revision: 3},
+	}
+
+	ctx := context.Background()
+	if err := storage.StoreChangeEventBatch(ctx, events); err != nil {
+		t.Fatalf("StoreChangeEventBatch failed: %v", err)
+	}
+
+	retrieved, err := storage.QueryChangesSince(ctx, time.Now().Add(-1*time.Hour))
+	if err != nil {
+		t.Fatalf("QueryChangesSince failed: %v", err)
+	}
+
+	if len(retrieved) != 3 {
+		t.Errorf("Expected 3 events, got %d", len(retrieved))
+	}
+
+	for i, event := range retrieved {
+		if event.ResourceID != events[i].ResourceID {
+			t.Errorf("Event %d: ResourceID = %s, want %s", i, event.ResourceID, events[i].ResourceID)
+		}
+		if event.ChangeType != events[i].ChangeType {
+			t.Errorf("Event %d: ChangeType = %s, want %s", i, event.ChangeType, events[i].ChangeType)
+		}
+	}
+}
+
+func TestMVCCStorage_StoreDriftEventBatch(t *testing.T) {
+	tmpDir := t.TempDir()
+	storage, err := NewMVCCStorage(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = storage.Close() }()
+
+	events := []DriftEvent{
+		{ResourceID: "i-001", DriftType: "tag_drift", Field: "env", Expected: "prod", Actual: "dev", Severity: "high", Timestamp: time.Now()},
+		{ResourceID: "i-002", DriftType: "config_drift", Field: "type", Expected: "t2.micro", Actual: "t2.small", Severity: "medium", Timestamp: time.Now()},
+	}
+
+	ctx := context.Background()
+	if err := storage.StoreDriftEventBatch(ctx, events); err != nil {
+		t.Fatalf("StoreDriftEventBatch failed: %v", err)
+	}
+
+	retrieved, err := storage.QueryDriftEvents(ctx, time.Now().Add(-1*time.Hour))
+	if err != nil {
+		t.Fatalf("QueryDriftEvents failed: %v", err)
+	}
+
+	if len(retrieved) != 2 {
+		t.Errorf("Expected 2 events, got %d", len(retrieved))
+	}
+
+	for i, event := range retrieved {
+		if event.ResourceID != events[i].ResourceID {
+			t.Errorf("Event %d: ResourceID = %s, want %s", i, event.ResourceID, events[i].ResourceID)
+		}
+		if event.Severity != events[i].Severity {
+			t.Errorf("Event %d: Severity = %s, want %s", i, event.Severity, events[i].Severity)
+		}
+	}
+}
+
+func TestMVCCStorage_StoreWastePatternBatch(t *testing.T) {
+	tmpDir := t.TempDir()
+	storage, err := NewMVCCStorage(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = storage.Close() }()
+
+	patterns := []WastePattern{
+		{PatternType: "idle", ResourceIDs: []string{"i-001"}, Confidence: 0.9, Reason: "Low CPU usage", Timestamp: time.Now()},
+		{PatternType: "orphaned", ResourceIDs: []string{"i-002", "i-003"}, Confidence: 0.95, Reason: "No owner tag", Timestamp: time.Now()},
+	}
+
+	ctx := context.Background()
+	if err := storage.StoreWastePatternBatch(ctx, patterns); err != nil {
+		t.Fatalf("StoreWastePatternBatch failed: %v", err)
+	}
+
+	retrieved, err := storage.QueryWastePatterns(ctx, time.Now().Add(-1*time.Hour))
+	if err != nil {
+		t.Fatalf("QueryWastePatterns failed: %v", err)
+	}
+
+	if len(retrieved) != 2 {
+		t.Errorf("Expected 2 patterns, got %d", len(retrieved))
+	}
+
+	for i, pattern := range retrieved {
+		if pattern.PatternType != patterns[i].PatternType {
+			t.Errorf("Pattern %d: PatternType = %s, want %s", i, pattern.PatternType, patterns[i].PatternType)
+		}
+		if pattern.Confidence != patterns[i].Confidence {
+			t.Errorf("Pattern %d: Confidence = %f, want %f", i, pattern.Confidence, patterns[i].Confidence)
+		}
+	}
+}
+
+func TestMVCCStorage_BatchRevisionNumbering(t *testing.T) {
+	tmpDir := t.TempDir()
+	storage, err := NewMVCCStorage(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = storage.Close() }()
+
+	initialRev := storage.CurrentRevision()
+
+	events := []ChangeEvent{
+		{ResourceID: "i-001", ChangeType: "created", Timestamp: time.Now()},
+		{ResourceID: "i-002", ChangeType: "created", Timestamp: time.Now()},
+		{ResourceID: "i-003", ChangeType: "created", Timestamp: time.Now()},
+	}
+
+	ctx := context.Background()
+	if err := storage.StoreChangeEventBatch(ctx, events); err != nil {
+		t.Fatalf("StoreChangeEventBatch failed: %v", err)
+	}
+
+	finalRev := storage.CurrentRevision()
+	expectedRev := initialRev + int64(len(events))
+
+	if finalRev != expectedRev {
+		t.Errorf("Revision = %d, want %d (increment of %d)", finalRev, expectedRev, len(events))
+	}
+}

--- a/storage/analyzer_queries.go
+++ b/storage/analyzer_queries.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -9,18 +10,57 @@ import (
 )
 
 // QueryChangesSince retrieves change events since a timestamp
-func (s *MVCCStorage) QueryChangesSince(ctx context.Context, since time.Time) ([][]byte, error) {
-	return s.queryEventsSince(ctx, bucketChanges, since)
+func (s *MVCCStorage) QueryChangesSince(ctx context.Context, since time.Time) ([]ChangeEvent, error) {
+	rawEvents, err := s.queryEventsSince(ctx, bucketChanges, since)
+	if err != nil {
+		return nil, err
+	}
+
+	events := make([]ChangeEvent, 0, len(rawEvents))
+	for _, data := range rawEvents {
+		var event ChangeEvent
+		if err := json.Unmarshal(data, &event); err != nil {
+			continue // Skip malformed events
+		}
+		events = append(events, event)
+	}
+	return events, nil
 }
 
 // QueryDriftEvents retrieves drift events since a timestamp
-func (s *MVCCStorage) QueryDriftEvents(ctx context.Context, since time.Time) ([][]byte, error) {
-	return s.queryEventsSince(ctx, bucketDrift, since)
+func (s *MVCCStorage) QueryDriftEvents(ctx context.Context, since time.Time) ([]DriftEvent, error) {
+	rawEvents, err := s.queryEventsSince(ctx, bucketDrift, since)
+	if err != nil {
+		return nil, err
+	}
+
+	events := make([]DriftEvent, 0, len(rawEvents))
+	for _, data := range rawEvents {
+		var event DriftEvent
+		if err := json.Unmarshal(data, &event); err != nil {
+			continue // Skip malformed events
+		}
+		events = append(events, event)
+	}
+	return events, nil
 }
 
 // QueryWastePatterns retrieves waste patterns since a timestamp
-func (s *MVCCStorage) QueryWastePatterns(ctx context.Context, since time.Time) ([][]byte, error) {
-	return s.queryEventsSince(ctx, bucketWaste, since)
+func (s *MVCCStorage) QueryWastePatterns(ctx context.Context, since time.Time) ([]WastePattern, error) {
+	rawEvents, err := s.queryEventsSince(ctx, bucketWaste, since)
+	if err != nil {
+		return nil, err
+	}
+
+	patterns := make([]WastePattern, 0, len(rawEvents))
+	for _, data := range rawEvents {
+		var pattern WastePattern
+		if err := json.Unmarshal(data, &pattern); err != nil {
+			continue // Skip malformed events
+		}
+		patterns = append(patterns, pattern)
+	}
+	return patterns, nil
 }
 
 // queryEventsSince is a generic query helper that returns raw JSON

--- a/storage/events.go
+++ b/storage/events.go
@@ -1,0 +1,41 @@
+package storage
+
+import (
+	"time"
+
+	"github.com/yairfalse/elava/types"
+)
+
+// ChangeEvent represents a detected infrastructure change
+type ChangeEvent struct {
+	ResourceID string            `json:"resource_id"`
+	ChangeType string            `json:"change_type"` // created, modified, disappeared
+	Timestamp  time.Time         `json:"timestamp"`
+	Revision   int64             `json:"revision"`
+	Previous   *types.Resource   `json:"previous,omitempty"`
+	Current    *types.Resource   `json:"current,omitempty"`
+	Metadata   map[string]string `json:"metadata,omitempty"`
+}
+
+// DriftEvent represents detected drift from desired state
+type DriftEvent struct {
+	ResourceID string            `json:"resource_id"`
+	DriftType  string            `json:"drift_type"` // tag_drift, config_drift, state_drift
+	Timestamp  time.Time         `json:"timestamp"`
+	Field      string            `json:"field"`
+	Expected   string            `json:"expected"`
+	Actual     string            `json:"actual"`
+	Severity   string            `json:"severity"` // low, medium, high, critical
+	Metadata   map[string]string `json:"metadata,omitempty"`
+}
+
+// WastePattern represents detected resource waste
+type WastePattern struct {
+	PatternType   string            `json:"pattern_type"` // idle, oversized, orphaned, unattached
+	ResourceIDs   []string          `json:"resource_ids"`
+	Timestamp     time.Time         `json:"timestamp"`
+	EstimatedCost float64           `json:"estimated_cost,omitempty"`
+	Confidence    float64           `json:"confidence"` // 0.0 to 1.0
+	Reason        string            `json:"reason"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+}

--- a/storage/interface_compliance_test.go
+++ b/storage/interface_compliance_test.go
@@ -1,0 +1,25 @@
+package storage
+
+import "testing"
+
+// TestInterfaceCompliance verifies MVCCStorage implements all interfaces
+// This test ensures compile-time verification of interface compliance
+func TestInterfaceCompliance(t *testing.T) {
+	// Complete Storage interface
+	var _ Storage = (*MVCCStorage)(nil)
+
+	// Observation interfaces
+	var _ ObservationStorage = (*MVCCStorage)(nil)
+	var _ ObservationWriter = (*MVCCStorage)(nil)
+	var _ ObservationReader = (*MVCCStorage)(nil)
+
+	// Analyzer event interfaces
+	var _ AnalyzerEventStorage = (*MVCCStorage)(nil)
+	var _ AnalyzerEventWriter = (*MVCCStorage)(nil)
+	var _ AnalyzerEventReader = (*MVCCStorage)(nil)
+
+	// Maintenance interfaces
+	var _ Compactor = (*MVCCStorage)(nil)
+	var _ StorageStats = (*MVCCStorage)(nil)
+	var _ Lifecycle = (*MVCCStorage)(nil)
+}

--- a/storage/interfaces.go
+++ b/storage/interfaces.go
@@ -31,9 +31,15 @@ type ObservationStorage interface {
 
 // AnalyzerEventWriter stores analyzer-generated events
 type AnalyzerEventWriter interface {
+	// Single event operations
 	StoreChangeEvent(ctx context.Context, event ChangeEvent) error
 	StoreDriftEvent(ctx context.Context, event DriftEvent) error
 	StoreWastePattern(ctx context.Context, pattern WastePattern) error
+
+	// Batch operations for performance
+	StoreChangeEventBatch(ctx context.Context, events []ChangeEvent) error
+	StoreDriftEventBatch(ctx context.Context, events []DriftEvent) error
+	StoreWastePatternBatch(ctx context.Context, patterns []WastePattern) error
 }
 
 // AnalyzerEventReader queries analyzer events

--- a/storage/interfaces.go
+++ b/storage/interfaces.go
@@ -1,0 +1,75 @@
+package storage
+
+import (
+	"context"
+	"time"
+
+	"github.com/yairfalse/elava/types"
+)
+
+// ObservationWriter records resource observations
+type ObservationWriter interface {
+	RecordObservation(resource types.Resource) (revision int64, err error)
+	RecordObservationBatch(resources []types.Resource) (revision int64, err error)
+	RecordDisappearance(resourceID string) (revision int64, err error)
+}
+
+// ObservationReader queries resource observations
+type ObservationReader interface {
+	GetResourceState(resourceID string) (*ResourceState, error)
+	GetStateAtRevision(resourceID string, revision int64) (*ResourceState, error)
+	GetResourcesByOwner(owner string) ([]*ResourceState, error)
+	GetAllCurrentResources() ([]*ResourceState, error)
+}
+
+// ObservationStorage combines read and write for observations
+type ObservationStorage interface {
+	ObservationWriter
+	ObservationReader
+	CurrentRevision() int64
+}
+
+// AnalyzerEventWriter stores analyzer-generated events
+type AnalyzerEventWriter interface {
+	StoreChangeEvent(ctx context.Context, event ChangeEvent) error
+	StoreDriftEvent(ctx context.Context, event DriftEvent) error
+	StoreWastePattern(ctx context.Context, pattern WastePattern) error
+}
+
+// AnalyzerEventReader queries analyzer events
+type AnalyzerEventReader interface {
+	QueryChangesSince(ctx context.Context, since time.Time) ([]ChangeEvent, error)
+	QueryDriftEvents(ctx context.Context, since time.Time) ([]DriftEvent, error)
+	QueryWastePatterns(ctx context.Context, since time.Time) ([]WastePattern, error)
+}
+
+// AnalyzerEventStorage combines analyzer event operations
+type AnalyzerEventStorage interface {
+	AnalyzerEventWriter
+	AnalyzerEventReader
+}
+
+// Compactor handles storage compaction
+type Compactor interface {
+	Compact(keepRevisions int64) error
+	CompactWithContext(ctx context.Context, keepRevisions int64) error
+}
+
+// StorageStats provides operational metrics
+type StorageStats interface {
+	Stats() (resourceCount int, currentRev int64, dbSizeBytes int64)
+}
+
+// Lifecycle manages storage lifecycle
+type Lifecycle interface {
+	Close() error
+}
+
+// Storage is the complete storage interface combining all capabilities
+type Storage interface {
+	ObservationStorage
+	AnalyzerEventStorage
+	Compactor
+	StorageStats
+	Lifecycle
+}


### PR DESCRIPTION
 Summary

  Successfully addressed Copilot's feedback and pushed the fix to PR #37.

  The Issue

  Key generation happened outside the transaction, creating a race condition where:
  - Key created with currentRev+1
  - Transaction fails
  - currentRev doesn't increment
  - Next operation uses same revision number → conflict!

  The Fix

  Moved makeAnalyzerEventKey() inside the db.Update() transaction to ensure atomicity:
  - Key generation and revision increment are now atomic
  - No revision conflicts possible
  - Both single and batch operations now consistent

  Verification

  ✅ All tests pass with race detector✅ Pushed to PR #37✅ Code follows CLAUDE.md standards