### PR TITLE
fix(cli): resolve build errors in cmd/elava

### DIFF
--- a/cmd/elava/main.go
+++ b/cmd/elava/main.go
@@ -1,24 +1,5 @@
 package main
 
-import (
-	"fmt"
-	"os"
-)
-
 func main() {
 	Execute()
-}
-
-// Execute runs the CLI application
-func Execute() {
-	// Simple placeholder - just run scan for now
-	cmd := &ScanCommand{
-		Region: "us-east-1",
-		Output: "table",
-	}
-
-	if err := cmd.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
-	}
 }

--- a/cmd/elava/scan.go
+++ b/cmd/elava/scan.go
@@ -72,14 +72,11 @@ func (cmd *ScanCommand) processResults(ctx context.Context, infra *scanInfra, re
 	cmd.logScanOperation(infra.wal, resources)
 
 	// Handle state changes
-	changes := cmd.handleStateChanges(infra.storage, resources)
+	cmd.handleStateChanges(infra.storage, resources)
 
 	// Find untracked resources
-	s := scanner.NewScanner()
-	untracked := s.FindUntracked(resources, scanner.TagConfig{
-		OwnerTag:   "elava:owner",
-		ManagedTag: "elava:managed",
-	})
+	tracker := scanner.NewTracker()
+	untracked := tracker.FindUntracked(ctx, resources)
 
 	// Apply risk filter if requested
 	if cmd.RiskOnly {


### PR DESCRIPTION
- Remove duplicate Execute() function from main.go (already defined in root.go)
- Fix scanner package usage: NewScanner() → NewTracker()
- Remove unused 'changes' variable
- Fix TagConfig struct reference (not needed with NewTracker)

Build now succeeds with no errors.

Note: Pre-existing test failure in TestEngine_Execute_PartialFailure (unrelated to this fix, will be addressed separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)