### PR TITLE
feat(policy): wire OPA policy loader into reconcile command

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,15 +121,16 @@ Read-only access:
 
 ```yaml
 # elava.yaml
-providers:
-  aws:
-    region: us-east-1
+version: "1.0"
+provider: aws
+region: us-east-1
 
-storage:
-  path: /var/lib/elava
-  retention: 30d
+# Optional: Policy enforcement with OPA
+policies:
+  path: ./policies/examples  # Omit to disable policy enforcement
 
 scanning:
+  enabled: true
   tiers:
     critical:
       scan_interval: 5m
@@ -141,6 +142,8 @@ scanning:
     standard:
       scan_interval: 1h
 ```
+
+**Policy enforcement is optional** - Elava works with or without OPA policies. Without policies, it only scans and stores observations.
 
 ## What's inside
 

--- a/cmd/elava/cmd_reconcile.go
+++ b/cmd/elava/cmd_reconcile.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/yairfalse/elava/config"
 	"github.com/yairfalse/elava/orchestrator"
+	"github.com/yairfalse/elava/policy"
 	"github.com/yairfalse/elava/providers"
 	"github.com/yairfalse/elava/providers/aws"
 	"github.com/yairfalse/elava/storage"
@@ -89,6 +90,18 @@ func runReconcile(cmd *cobra.Command, args []string) error {
 	// Create orchestrator
 	orch := orchestrator.NewOrchestrator(store)
 	orch = orch.WithScanner(scanner)
+
+	// Load policies if configured
+	if cfg.Policies.Path != "" {
+		fmt.Printf("📋 Loading policies from: %s\n", cfg.Policies.Path)
+		loader := policy.NewPolicyLoader(cfg.Policies.Path, orch.PolicyEngine())
+		if err := loader.LoadPolicies(ctx); err != nil {
+			return fmt.Errorf("failed to load policies: %w", err)
+		}
+		fmt.Println("✅ Policies loaded successfully")
+	} else {
+		fmt.Println("ℹ️  Policy enforcement disabled (no policies configured)")
+	}
 
 	// If dry-run, use enforcer without provider
 	if dryRun {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,71 @@
+version: "1.0"
+provider: aws
+region: us-east-1
+
+# Policy enforcement
+policies:
+  path: ./policies/examples
+
+# Scanning configuration
+scanning:
+  enabled: true
+  adaptive_hours: true
+
+  tiers:
+    critical:
+      description: "Critical production resources"
+      scan_interval: 15m
+      patterns:
+        - type: rds
+          tags:
+            environment: production
+        - type: nat_gateway
+        - type: ec2
+          instance_type_pattern: "*xlarge"
+
+    production:
+      description: "Production resources"
+      scan_interval: 1h
+      patterns:
+        - tags:
+            environment: production
+        - status: running
+
+    standard:
+      description: "Development and staging"
+      scan_interval: 4h
+      patterns:
+        - tags:
+            environment: development
+        - tags:
+            environment: staging
+
+    archive:
+      description: "Rarely changing resources"
+      scan_interval: 24h
+      patterns:
+        - types: [snapshot, ami]
+        - status: stopped
+
+  change_detection:
+    enabled: true
+    check_interval: 5m
+    alert_on:
+      new_untagged_resources: true
+      status_changes: true
+      disappeared_resources: true
+      cost_increases: true
+      tag_changes: [Owner, Environment]
+
+  performance:
+    batch_size: 1000
+    parallel_workers: 4
+    rate_limit: 100
+
+# Behavior rules
+rules:
+  protect_blessed: true
+  notify_on_orphans: true
+  grace_period: 24h
+  auto_delete: false
+  require_approval: true

--- a/config.minimal.yaml
+++ b/config.minimal.yaml
@@ -1,0 +1,5 @@
+version: "1.0"
+provider: aws
+region: us-east-1
+
+# No policies configured - scan and store only, no enforcement

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	Resources map[string]types.ResourceSpec `yaml:"resources,omitempty"`
 	Rules     Rules                         `yaml:"rules,omitempty"`
 	Scanning  ScanningConfig                `yaml:"scanning,omitempty"`
+	Policies  PoliciesConfig                `yaml:"policies,omitempty"`
 }
 
 // ScanningConfig defines the tiered scanning strategy
@@ -76,6 +77,11 @@ type Rules struct {
 	GracePeriod     time.Duration `yaml:"grace_period"`
 	AutoDelete      bool          `yaml:"auto_delete"`
 	RequireApproval bool          `yaml:"require_approval"`
+}
+
+// PoliciesConfig defines policy enforcement configuration
+type PoliciesConfig struct {
+	Path string `yaml:"path"`
 }
 
 // LoadConfig loads configuration from file

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -36,6 +36,11 @@ func (o *Orchestrator) WithScanner(s Scanner) *Orchestrator {
 	return o
 }
 
+// PolicyEngine returns the policy engine for loading policies
+func (o *Orchestrator) PolicyEngine() *policy.PolicyEngine {
+	return o.policyEngine
+}
+
 // RunCycle runs one reconciliation cycle
 func (o *Orchestrator) RunCycle(ctx context.Context) (*CycleResult, error) {
 	result := &CycleResult{

--- a/policies/examples/orphans.rego
+++ b/policies/examples/orphans.rego
@@ -1,0 +1,68 @@
+package elava.policies.orphans
+
+import future.keywords.if
+import future.keywords.in
+
+# Default: allow resources with proper tags
+default allow := true
+
+# Flag resources missing critical tags
+flag if {
+    missing_critical_tags
+}
+
+# Notify about resources without owner
+notify if {
+    missing_owner_tag
+}
+
+# Resource is missing critical tags
+missing_critical_tags if {
+    not input.resource.tags["elava:managed"]
+}
+
+# Resource is missing owner tag
+missing_owner_tag if {
+    not input.resource.tags["Owner"]
+    not input.resource.tags["owner"]
+}
+
+# Build decision based on resource state
+decision := {
+    "action": action,
+    "reason": reason,
+    "confidence": confidence
+}
+
+# Determine action based on conditions
+action := "flag" if missing_critical_tags
+action := "notify" if {
+    not missing_critical_tags
+    missing_owner_tag
+}
+action := "ignore" if {
+    not missing_critical_tags
+    not missing_owner_tag
+}
+
+# Provide reason for decision
+reason := "Missing elava:managed tag - resource is untracked" if missing_critical_tags
+reason := "Missing Owner tag - unclear ownership" if {
+    not missing_critical_tags
+    missing_owner_tag
+}
+reason := "Resource properly tagged" if {
+    not missing_critical_tags
+    not missing_owner_tag
+}
+
+# Confidence based on tag completeness
+confidence := 0.9 if missing_critical_tags
+confidence := 0.7 if {
+    not missing_critical_tags
+    missing_owner_tag
+}
+confidence := 1.0 if {
+    not missing_critical_tags
+    not missing_owner_tag
+}

--- a/policies/examples/security.rego
+++ b/policies/examples/security.rego
@@ -1,0 +1,110 @@
+package elava.policies.security
+
+import future.keywords.if
+import future.keywords.in
+
+# Default: allow resources
+default allow := true
+
+# Flag security groups with overly permissive rules
+flag if {
+    input.resource.type == "security_group"
+    has_public_ingress
+}
+
+# Notify about unencrypted storage
+notify if {
+    is_storage_resource
+    not is_encrypted
+}
+
+# Check for public ingress (0.0.0.0/0)
+has_public_ingress if {
+    input.resource.type == "security_group"
+    some rule in input.resource.config.ingress_rules
+    rule.cidr == "0.0.0.0/0"
+}
+
+# Identify storage resources
+is_storage_resource if {
+    input.resource.type in ["ebs_volume", "s3_bucket", "rds"]
+}
+
+# Check encryption status
+is_encrypted if {
+    input.resource.config.encrypted == true
+}
+
+# Build decision
+decision := {
+    "action": action,
+    "reason": reason,
+    "confidence": confidence,
+    "metadata": metadata
+}
+
+# Determine action
+action := "flag" if {
+    input.resource.type == "security_group"
+    has_public_ingress
+}
+
+action := "notify" if {
+    is_storage_resource
+    not is_encrypted
+    not action == "flag"
+}
+
+action := "ignore" if {
+    not has_public_ingress
+    not (is_storage_resource; not is_encrypted)
+}
+
+# Provide reason
+reason := "Security group allows public access (0.0.0.0/0)" if {
+    input.resource.type == "security_group"
+    has_public_ingress
+}
+
+reason := sprintf("Unencrypted %s detected", [input.resource.type]) if {
+    is_storage_resource
+    not is_encrypted
+    not has_public_ingress
+}
+
+reason := "Security checks passed" if {
+    not has_public_ingress
+    not (is_storage_resource; not is_encrypted)
+}
+
+# Confidence levels
+confidence := 0.95 if has_public_ingress
+confidence := 0.85 if {
+    not has_public_ingress
+    is_storage_resource
+    not is_encrypted
+}
+confidence := 1.0 if {
+    not has_public_ingress
+    not (is_storage_resource; not is_encrypted)
+}
+
+# Metadata for enforcement
+metadata := {
+    "severity": "high",
+    "tags_to_add": {"security:risk": "high"}
+} if has_public_ingress
+
+metadata := {
+    "severity": "medium",
+    "tags_to_add": {"security:encryption": "missing"}
+} if {
+    not has_public_ingress
+    is_storage_resource
+    not is_encrypted
+}
+
+metadata := {} if {
+    not has_public_ingress
+    not (is_storage_resource; not is_encrypted)
+}


### PR DESCRIPTION
Add optional OPA policy enforcement to reconcile command:
- Add PoliciesConfig to config with path field
- Wire policy loader in cmd_reconcile to load policies before reconciliation
- Expose PolicyEngine() getter on Orchestrator
- Add example orphan detection policy (orphans.rego)
- Add example security compliance policy (security.rego)
- Create config.example.yaml with policies enabled
- Create config.minimal.yaml for discovery-only mode
- Update README to document optional policy enforcement

Policy enforcement is completely optional:
- No policies path = discovery only (scan + store)
- With policies path = full enforcement (scan + policy + enforce)

🤖 Generated with [Claude Code](https://claude.com/claude-code)